### PR TITLE
feat: associated classes

### DIFF
--- a/client/src/components/calendar/Calendar.tsx
+++ b/client/src/components/calendar/Calendar.tsx
@@ -553,6 +553,9 @@ const Calendar: React.FC<CalendarProps> = ({
                                       {course.subject} {course.catalogNumber}
                                     </p>
                                     <p className="order-1 font-semibold text-gray-700">
+                                      {course.section ? "Discussion/Lab" : ""}
+                                    </p>
+                                    <p className="order-1 font-semibold text-gray-700">
                                       {course.section
                                         ? "Section " + course.section
                                         : ""}
@@ -566,6 +569,9 @@ const Calendar: React.FC<CalendarProps> = ({
                                     </p>
                                     <p className="order-1 font-semibold text-gray-700">
                                       {course.catalogNumber}
+                                    </p>
+                                    <p className="order-1 font-semibold text-gray-700">
+                                      {course.section ? "Discussion/Lab" : ""}
                                     </p>
                                     <p className="order-1 font-semibold text-gray-700">
                                       {course.section

--- a/client/src/components/calendar/Calendar.tsx
+++ b/client/src/components/calendar/Calendar.tsx
@@ -548,15 +548,16 @@ const Calendar: React.FC<CalendarProps> = ({
                                   </button>
                                 </div>
                                 {course.subject.length <= 7 && (
-                                  <p className="order-1 font-semibold text-gray-700">
-                                    {course.section
-                                      ? course.catalogNumber +
-                                        " " +
-                                        "Discussion"
-                                      : course.subject +
-                                        " " +
-                                        course.catalogNumber}
-                                  </p>
+                                  <>
+                                    <p className="order-1 font-semibold text-gray-700">
+                                      {course.subject} {course.catalogNumber}
+                                    </p>
+                                    <p className="order-1 font-semibold text-gray-700">
+                                      {course.section
+                                        ? "Section " + course.section
+                                        : ""}
+                                    </p>
+                                  </>
                                 )}
                                 {course.subject.length > 7 && (
                                   <>
@@ -565,6 +566,11 @@ const Calendar: React.FC<CalendarProps> = ({
                                     </p>
                                     <p className="order-1 font-semibold text-gray-700">
                                       {course.catalogNumber}
+                                    </p>
+                                    <p className="order-1 font-semibold text-gray-700">
+                                      {course.section
+                                        ? "Section " + course.section
+                                        : ""}
                                     </p>
                                   </>
                                 )}

--- a/client/src/components/calendar/Calendar.tsx
+++ b/client/src/components/calendar/Calendar.tsx
@@ -199,11 +199,16 @@ const Calendar: React.FC<CalendarProps> = ({
     updateCourses(allCurrentCourses);
   }, [calendarCourses]);
 
-  const handleRemoveCourse = (courseId: string) => {
+  const handleRemoveCourse = (courseId: string, section?: string) => {
     // GET THE COURSE WE ARE REMOVING
     const courseToRemove = calendarCourses.filter((course) => {
-      return course.courseNumber === courseId;
+      if (section) {
+        return course.section === section;
+      } else {
+        return course.courseNumber === courseId;
+      }
     });
+    console.log(courseToRemove);
     // HANDLE DELETION FROM THE DB
     if (currentUser?.email !== "msk@gmail.com") {
       updateCalendarArrayRemoveCourse(calendarId, courseToRemove[0]);
@@ -211,7 +216,11 @@ const Calendar: React.FC<CalendarProps> = ({
     // REMOVE FROM THE UI
     setCalendarCourses((currentCourses: CalendarCourse[]) =>
       currentCourses.filter((course) => {
-        return course.courseNumber !== courseId;
+        if (section) {
+          return course.section != section;
+        } else {
+          return course.courseNumber != courseId;
+        }
       })
     );
   };
@@ -506,7 +515,10 @@ const Calendar: React.FC<CalendarProps> = ({
                                     type="button"
                                     className="rounded-md bg-none text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
                                     onClick={() =>
-                                      handleRemoveCourse(course.courseNumber)
+                                      handleRemoveCourse(
+                                        course.courseNumber,
+                                        course.section
+                                      )
                                     }
                                   >
                                     <span className="sr-only">Close</span>
@@ -538,7 +550,7 @@ const Calendar: React.FC<CalendarProps> = ({
                                 </div>
                                 {course.subject.length <= 7 && (
                                   <p className="order-1 font-semibold text-gray-700">
-                                    {course.courseNumber.length > 5
+                                    {course.section
                                       ? course.catalogNumber +
                                         " " +
                                         "Discussion"

--- a/client/src/components/calendar/Calendar.tsx
+++ b/client/src/components/calendar/Calendar.tsx
@@ -538,7 +538,13 @@ const Calendar: React.FC<CalendarProps> = ({
                                 </div>
                                 {course.subject.length <= 7 && (
                                   <p className="order-1 font-semibold text-gray-700">
-                                    {course.subject} {course.catalogNumber}
+                                    {course.courseNumber.length > 5
+                                      ? course.catalogNumber +
+                                        " " +
+                                        "Discussion"
+                                      : course.subject +
+                                        " " +
+                                        course.catalogNumber}
                                   </p>
                                 )}
                                 {course.subject.length > 7 && (

--- a/client/src/components/calendar/Calendar.tsx
+++ b/client/src/components/calendar/Calendar.tsx
@@ -195,7 +195,6 @@ const Calendar: React.FC<CalendarProps> = ({
   // Meaning - take the first element as gospel - this is when the course meets
   useEffect(() => {
     const allCurrentCourses = [...calendarCourses];
-    console.log("ALL CALENDAR COURSES");
     updateCourses(allCurrentCourses);
   }, [calendarCourses]);
 

--- a/client/src/components/schedule/Schedule.tsx
+++ b/client/src/components/schedule/Schedule.tsx
@@ -64,7 +64,6 @@ const Schedule: React.FC<ScheduleProps> = ({
       subject: subject,
       courseNumber: courseNumber,
     }));
-
     setOpenDetailModal(() => true);
   };
 
@@ -145,9 +144,13 @@ const Schedule: React.FC<ScheduleProps> = ({
   }, [scheduleCourses]);
 
   // remove a course based on the courseNumber
-  const handleRemoveCourse = (courseId: string) => {
+  const handleRemoveCourse = (courseId: string, section?: string) => {
     const courseToRemove = scheduleCourses.filter((course) => {
-      return course.courseNumber === courseId;
+      if (section) {
+        return course.section === section;
+      } else {
+        return course.courseNumber === courseId;
+      }
     });
     // HANDLE DELETION FROM THE DB
     if (currentUser?.email !== "msk@gmail.com") {
@@ -157,7 +160,11 @@ const Schedule: React.FC<ScheduleProps> = ({
     // REMOVE FROM THE UI
     setScheduleCourses((currentCourses: ScheduleCourse[]) =>
       currentCourses.filter((course) => {
-        return course.courseNumber !== courseId;
+        if (section) {
+          return course.section != section;
+        } else {
+          return course.courseNumber != courseId;
+        }
       })
     );
   };
@@ -241,9 +248,6 @@ const Schedule: React.FC<ScheduleProps> = ({
                         <button
                           className="font-small text-indigo-600 hover:text-indigo-500 hover:underline"
                           onClick={() => {
-                            console.log(
-                              "View more details on this course was requested!"
-                            );
                             handleDetailClick(
                               course.termId,
                               course.school,
@@ -261,7 +265,9 @@ const Schedule: React.FC<ScheduleProps> = ({
                     <span className="sr-only">Close</span>
                     <XIcon
                       className="relative bottom-10 left-2 text-gray-400 h-4 w-4 hover:cursor-pointer"
-                      onClick={() => handleRemoveCourse(course.courseNumber)}
+                      onClick={() =>
+                        handleRemoveCourse(course.courseNumber, course.section)
+                      }
                       aria-hidden="true"
                     />
                   </div>

--- a/client/src/components/schedule/Schedule.tsx
+++ b/client/src/components/schedule/Schedule.tsx
@@ -219,11 +219,20 @@ const Schedule: React.FC<ScheduleProps> = ({
                     <div className="flex-1 truncate">
                       <div className="flex items-center space-x-3">
                         <h3 className="text-gray-900 text-md font-bold font-atkinson truncate">
-                          {course.subject} {course.catalogNumber}
+                          {course.subject} {course.catalogNumber}{" "}
+                          {course.courseTitle
+                            .toLocaleLowerCase()
+                            .includes("Dis".toLowerCase())
+                            ? "Discussion"
+                            : ""}
                         </h3>
                       </div>
                       <p className="font-atkinson mt-1 text-gray-500 text-sm truncate">
-                        {course.courseTitle}
+                        {course.courseTitle
+                          .toLocaleLowerCase()
+                          .includes("Dis".toLowerCase())
+                          ? course.catalogNumber + " " + "Discussion"
+                          : course.courseTitle}
                       </p>
                       <p className="font-atkinson mt-1 text-gray-500 text-sm truncate">
                         {course.school}

--- a/client/src/components/search/Search.tsx
+++ b/client/src/components/search/Search.tsx
@@ -167,6 +167,7 @@ const Search: React.FC<SearchProps> = ({
             return (
               <SearchItem
                 key={course.id}
+                searchQuery={searchQuery}
                 termId={termId as string}
                 school={course.school}
                 subject={course.subject}
@@ -206,6 +207,7 @@ const Search: React.FC<SearchProps> = ({
             return (
               <SearchItem
                 key={course.id}
+                searchQuery={searchQuery}
                 termId={termId as string}
                 school={course.school}
                 subject={course.subject}

--- a/client/src/components/search/SearchItem.tsx
+++ b/client/src/components/search/SearchItem.tsx
@@ -321,9 +321,16 @@ const SearchItem: React.FC<SearchItemProps> = ({
 
     return new Promise<void>((resolve) => {
       fetchAssociatedCourses().then((data) => {
-        if (data.body.length > 1) {
-          console.log(data.body);
-          setAssociatedClasses(data.body);
+        console.log(data.body);
+        const filteredCourses: Record<string, any>[] = [];
+        for (let i = 0; i < data.body.length; i++) {
+          if (data.body[i].CLASS_MTG_INFO2[0].MEETING_TIME === "NO DATA") {
+            continue;
+          }
+          filteredCourses.push(data.body[i]);
+        }
+        if (filteredCourses.length > 1) {
+          setAssociatedClasses(filteredCourses);
           setAreThereAssociatedClasses(true);
         }
         resolve();
@@ -409,8 +416,8 @@ const SearchItem: React.FC<SearchItemProps> = ({
           >
             <div className="px-4 pt-4 pb-0.5 sm:px-6">
               <p className="font-atkinson text-xs font-semibold text-gray-900 pr-5 ">
-                Choose a discussion section for {subject} {catalogNumber}{" "}
-                (optional):
+                Choose a {associatedClasses[0].section?.toLowerCase()} section
+                for {subject} {catalogNumber} (optional):
               </p>
               <XIcon
                 className="relative bottom-6 left-60 text-gray-400 h-4 w-4 hover:cursor-pointer"
@@ -440,7 +447,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
                         <div className="flex items-center justify-between">
                           <p className="truncate text-sm font-medium text-gray-900">
                             {course.COMPONENT === "DIS"
-                              ? "Discussion"
+                              ? "Section " + course.SECTION
                               : course.COMPONENT}
                           </p>
                           <div className="ml-2 flex flex-shrink-0">

--- a/client/src/components/search/SearchItem.tsx
+++ b/client/src/components/search/SearchItem.tsx
@@ -230,10 +230,19 @@ const SearchItem: React.FC<SearchItemProps> = ({
       SECTION: string;
       COMPONENT: string;
       CLASS_MTG_INFO2: { ROOM: string; MEETING_TIME: string }[];
-    },
-    discussion_index: number
+    }
   ) => {
     if (view === "Schedule") {
+      // see if this course is in the calendarCourses already. If not, add it
+      for (let i = 0; i < scheduleCourses.length; i++) {
+        if (scheduleCourses[i].section === associatedCourse.SECTION) {
+          setError(`This section is already present in ${view.toLowerCase()}!`);
+          setTimeout(() => {
+            setError("");
+          }, 3000);
+          return;
+        }
+      }
       setScheduleCourses((priorCourses: ScheduleCourse[]) => [
         ...priorCourses,
         {
@@ -245,7 +254,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
               ? "Discussion"
               : associatedCourse.COMPONENT,
           catalogNumber: catalogNumber,
-          courseNumber: courseNumber + discussion_index,
+          courseNumber: courseNumber,
           classMeetingInfo: associatedCourse.CLASS_MTG_INFO2,
           termDescription: termDescription,
           color: color,
@@ -253,6 +262,16 @@ const SearchItem: React.FC<SearchItemProps> = ({
         },
       ]);
     } else {
+      // see if this course is in the calendarCourses already. If not, add it
+      for (let i = 0; i < calendarCourses.length; i++) {
+        if (calendarCourses[i].section === associatedCourse.SECTION) {
+          setError(`Course already present in ${view.toLowerCase()}!`);
+          setTimeout(() => {
+            setError("");
+          }, 3000);
+          return;
+        }
+      }
       setCalendarCourses((priorCourses: CalendarCourse[]) => [
         ...priorCourses,
         {
@@ -414,7 +433,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
                     className="hover:scale-[101%] transition-all hover:cursor-pointer hover:bg-white/30"
                   >
                     <a
-                      onClick={() => addAssociatedClassTo(view, course, id)}
+                      onClick={() => addAssociatedClassTo(view, course)}
                       className="block hover:bg-gray-50"
                     >
                       <div className="px-4 py-4 sm:px-6">
@@ -441,7 +460,9 @@ const SearchItem: React.FC<SearchItemProps> = ({
           </div>
         )}
         <div className="mt-2 max-w-xl text-sm text-gray-500">
-          {loading && <p>Searching for associated courses...</p>}
+          {loading && !areThereAssociatedClasses && (
+            <p>Searching for associated courses...</p>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/search/SearchItem.tsx
+++ b/client/src/components/search/SearchItem.tsx
@@ -227,6 +227,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
   const addAssociatedClassTo = (
     view: "Calendar" | "Schedule",
     associatedCourse: {
+      SECTION: string;
       COMPONENT: string;
       CLASS_MTG_INFO2: { ROOM: string; MEETING_TIME: string }[];
     },
@@ -248,10 +249,10 @@ const SearchItem: React.FC<SearchItemProps> = ({
           classMeetingInfo: associatedCourse.CLASS_MTG_INFO2,
           termDescription: termDescription,
           color: color,
+          section: associatedCourse.SECTION,
         },
       ]);
     } else {
-      console.log("CALENDAR UPDATE");
       setCalendarCourses((priorCourses: CalendarCourse[]) => [
         ...priorCourses,
         {
@@ -259,9 +260,10 @@ const SearchItem: React.FC<SearchItemProps> = ({
           school: school,
           subject: subject,
           catalogNumber: catalogNumber,
-          courseNumber: courseNumber + discussion_index,
+          courseNumber: courseNumber,
           classMeetingInfo: associatedCourse.CLASS_MTG_INFO2,
           color: color,
+          section: associatedCourse.SECTION,
         },
       ]);
     }
@@ -401,6 +403,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
               {associatedClasses.map(
                 (
                   course: {
+                    SECTION: string;
                     COMPONENT: string;
                     CLASS_MTG_INFO2: { ROOM: string; MEETING_TIME: string }[];
                   },

--- a/client/src/components/search/SearchItem.tsx
+++ b/client/src/components/search/SearchItem.tsx
@@ -376,6 +376,9 @@ const SearchItem: React.FC<SearchItemProps> = ({
             Meeting time:{" "}
             {!classMeetingInfo || !classMeetingInfo.length
               ? "N/A"
+              : classMeetingInfo[0].MEETING_TIME.includes("Sa") ||
+                classMeetingInfo[0].MEETING_TIME.includes("Su")
+              ? "N/A"
               : classMeetingInfo[0].MEETING_TIME}
           </p>
         </div>
@@ -391,20 +394,23 @@ const SearchItem: React.FC<SearchItemProps> = ({
           </button>
         </div>
         <div className="font-atkinson text-sm">
-          {classMeetingInfo && classMeetingInfo.length > 0 && (
-            <button
-              // disable
-              className="text-[.75rem] text-indigo-600 hover:text-indigo-500 hover:underline"
-              onClick={() =>
-                view !== "Calendar"
-                  ? handleViewClick(view)
-                  : handleCollisionCheck()
-              }
-            >
-              {" "}
-              Add to {view} <span aria-hidden="true">&rarr;</span>
-            </button>
-          )}
+          {classMeetingInfo &&
+            classMeetingInfo.length > 0 &&
+            !(classMeetingInfo[0].MEETING_TIME.includes("Sa") ||
+              classMeetingInfo[0].MEETING_TIME.includes("Su")) && (
+              <button
+                // disable
+                className="text-[.75rem] text-indigo-600 hover:text-indigo-500 hover:underline"
+                onClick={() =>
+                  view !== "Calendar"
+                    ? handleViewClick(view)
+                    : handleCollisionCheck()
+                }
+              >
+                {" "}
+                Add to {view} <span aria-hidden="true">&rarr;</span>
+              </button>
+            )}
         </div>
         {/* If there were any errors */}
         <div className="mt-2 max-w-xl text-sm text-gray-500">
@@ -448,7 +454,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
                           <p className="truncate text-sm font-medium text-gray-900">
                             {course.COMPONENT === "DIS"
                               ? "Section " + course.SECTION
-                              : course.COMPONENT}
+                              : "Lab " + course.SECTION}
                           </p>
                           <div className="ml-2 flex flex-shrink-0">
                             <p

--- a/client/src/firebase/calendarService.ts
+++ b/client/src/firebase/calendarService.ts
@@ -63,6 +63,7 @@ const updateCalendarArrayRemoveCourse = async (
   courseData: CalendarCourse
 ): Promise<void> => {
   const calendarRef = doc(db, "calendars", calendarId);
+  console.log(courseData);
   await updateDoc(calendarRef, {
     lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),
     coursesData: arrayRemove(courseData),

--- a/client/src/types/calendar.d.ts
+++ b/client/src/types/calendar.d.ts
@@ -8,4 +8,6 @@ export interface CalendarCourse {
   courseNumber: string;
   classMeetingInfo: { ROOM: string; MEETING_TIME: string }[] | [];
   color: string;
+  // for discussion sections
+  section?: string;
 }

--- a/client/src/types/schedule.d.ts
+++ b/client/src/types/schedule.d.ts
@@ -11,4 +11,6 @@ export interface ScheduleCourse {
   classMeetingInfo: { ROOM: string; MEETING_TIME: string }[] | [] | null;
   termDescription: string;
   color: string;
+  // for discussions
+  section?: string;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -466,6 +466,50 @@ app.get("/api/v1/get_course_detail/", async (req, res) => {
   );
 });
 
+/**
+ * method: GET
+ * function: returns a detailed list of course attributes given a term, school, subject, and course number
+ */
+app.get("/api/v1/get_course_associated_classes/", async (req, res) => {
+  const termId = req.query.termId;
+  const schoolId = req.query.schoolId;
+  const subjectId = req.query.subjectId;
+  const courseId = req.query.courseId;
+
+  if (!termId || !schoolId || !subjectId || !courseId)
+    res.status(500).json({ type: "error", message: "Missing parameters!" });
+
+  const url = `${coursesURL}${termId}/${schoolId}/${subjectId}/${courseId}`;
+
+  request(
+    {
+      url: url,
+      headers: {
+        apikey: process.env.API_KEY as string,
+      },
+    },
+    (error, response, body) => {
+      if (error || response.statusCode !== 200) {
+        return res.status(500).json({ type: "error", message: response.body });
+      }
+
+      const oneClassData = JSON.parse(body).NW_CD_ONECLASS_RESP;
+      console.log(oneClassData);
+      const classDescription = oneClassData.CLASSDESCR[0];
+      const associatedClasses =
+        classDescription.ASSOCIATED_CLASS === undefined
+          ? null
+          : classDescription.ASSOCIATED_CLASS;
+
+      res.json({
+        status: 200,
+        results: associatedClasses.length,
+        body: associatedClasses,
+      });
+    }
+  );
+});
+
 app.get("/", (req, res) => {
   res.status(200).send({ ok: true });
 });


### PR DESCRIPTION
### Why
- Associated classes are labs and discussion sections for course X
- Previously, if course X had either lab or discussion sections, we would not include those in the course selection process
- This is a problem when courses have them (or many of them)

### What
- Adds associated course selection to the `SearchItem` modal
- Searches for a set of associated courses after course X is selected. If any are found, it displays them to choose from
- Saves them in firebase, and persists them in the schedule and calendar views
- UI tweaks to show discussion and lab sections
- Some other minor fixes, including filtering out courses on Saturday and Sunday